### PR TITLE
:bear: 動的OGP表示されないバグ修正

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,8 @@
 <% if @post.images.present? %>
   <% assign_meta_tags title: @post.title, image: @post.images.first.url %>
+<% else %>
+  <% assign_meta_tags title: @post.title %>
 <% end %>
-<% assign_meta_tags title: @post.title %>
 
 <div class="min-h-screen">
   <div class="flex justify-center my-14">


### PR DESCRIPTION
LINEでは確実に表示されるようになった。
X（Twitter）はまだポストはしていないため
ポスト編集画面の時点ではOGPが出るものとでないものがある。
OGPの確認ツールなどで確認すると動作は問題なし。
リリース後に確認する。